### PR TITLE
Use shlibs for dependencies, use cdylib-link-lines

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,6 @@ Build-Depends:
   cargo,
   rustc (>=1.36.0),
   libgtk-3-dev,
-  libxml2-dev,
   pkg-config,
 Standards-Version: 4.3.0
 Homepage: https://github.com/pop-os/theme-switcher

--- a/debian/control
+++ b/debian/control
@@ -15,8 +15,6 @@ Homepage: https://github.com/pop-os/theme-switcher
 Package: libpop-theme-switcher
 Architecture: amd64
 Depends:
-  libgtk-3-0,
-  libxml2,
   ${misc:Depends},
   ${shlibs:Depends}
 Description: Pop theme switcher widget library

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[build-dependencies]
+cdylib-link-lines = "0.1"
+
 [lib]
 name = "pop_theme_switcher"
 crate-type = [ "cdylib" ]

--- a/ffi/build.rs
+++ b/ffi/build.rs
@@ -1,6 +1,8 @@
 use std::{env, fs::File, io::Write, path::PathBuf};
 
 fn main() {
+    cdylib_link_lines::metabuild();
+
     let target_dir = PathBuf::from("../target");
 
     let pkg_config = format!(


### PR DESCRIPTION
Using `shlibs` to generate the run-time library dependencies is the correct method in Debian packaging conventions, and is effective at determining what dependencies and versions are needed.

Using `cdylib-link-lines` adds a major version to the library's `SONAME`, which seems to be sufficient to get `dpkg-shlibdeps` to not produce a warning, and successfully output the library dependency.