### PR TITLE
Add arm64 builds

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Standards-Version: 4.3.0
 Homepage: https://github.com/pop-os/theme-switcher
 
 Package: libpop-theme-switcher
-Architecture: amd64
+Architecture: amd64 arm64
 Depends:
   ${misc:Depends},
   ${shlibs:Depends}


### PR DESCRIPTION
This is required to get pop-gnome-initial-setup to build