### PR TITLE
improv: Allow reflowing for narrow width

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,6 @@ impl PopThemeSwitcher {
         let selection = cascade! {
             ImageSelection::new(&variants, ImageSrc::Resource(""), handler);
             ..set_max_children_per_line(2);
-            ..set_min_children_per_line(2);
             ..set_column_spacing(24);
             ..set_row_spacing(24);
             ..set_halign(gtk::Align::Center);


### PR DESCRIPTION
As suggested on https://github.com/pop-os/gnome-control-center/pull/202.

Will  require update to desktop widget with this version to apply on hirsute/impish.