### PR TITLE
Add color scheme and meld settings, remove dead code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "atk"
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
@@ -44,9 +44,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cairo-rs"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9164355c892b026d6257e696dde5f3cb39beb3718297f0f161b562fe2ee3ab86"
+checksum = "33b5725979db0c586d98abad2193cdb612dd40ef95cd26bd99851bf93b3cb482"
 dependencies = [
  "bitflags",
  "cairo-sys-rs",
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-sys-rs"
-version = "0.14.0"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c9c3928781e8a017ece15eace05230f04b647457d170d2d9641c94a444ff80"
+checksum = "b448b876970834fda82ba3aeaccadbd760206b75388fc5c1b02f1e343b697570"
 dependencies = [
  "glib-sys",
  "libc",
@@ -106,14 +106,14 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "derive_more"
-version = "0.99.16"
+version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.0",
  "syn",
 ]
 
@@ -141,29 +141,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e1c54951450cbd39f3dbcf1005ac413b49487dabf18a720ad2383eccfeffb92"
 dependencies = [
  "memoffset",
- "rustc_version",
+ "rustc_version 0.3.3",
 ]
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -172,23 +172,22 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
- "autocfg",
  "futures-core",
  "futures-task",
  "pin-project-lite",
@@ -364,8 +363,8 @@ dependencies = [
 
 [[package]]
 name = "gtk-extras"
-version = "0.3.0"
-source = "git+https://github.com/pop-os/gtk-extras#2a56671896afe7b363306963b2e012bbfd75341e"
+version = "0.3.1"
+source = "git+https://github.com/pop-os/gtk-extras#8dae9fee5f6d79a9e3c225308a9a8c54709dc8c3"
 dependencies = [
  "cairo-rs",
  "cascade",
@@ -432,18 +431,18 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.103"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "log"
@@ -456,18 +455,18 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "pango"
@@ -505,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pin-utils"
@@ -517,9 +516,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.20"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "pop-theme-switcher"
@@ -533,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
  "thiserror",
  "toml",
@@ -567,18 +566,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.30"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "b4af2ec4714533fcdf07e886f17025ace8b997b9ce51204ee69b6da831c3da57"
 dependencies = [
  "proc-macro2",
 ]
@@ -589,7 +588,16 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
- "semver",
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.6",
 ]
 
 [[package]]
@@ -602,6 +610,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+
+[[package]]
 name = "semver-parser"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,15 +626,15 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -635,9 +649,9 @@ checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "strum"
@@ -659,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -677,7 +691,7 @@ dependencies = [
  "anyhow",
  "cfg-expr",
  "heck",
- "itertools 0.10.1",
+ "itertools 0.10.3",
  "pkg-config",
  "strum",
  "strum_macros",
@@ -727,9 +741,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-xid"
@@ -751,9 +765,9 @@ checksum = "1c18c859eead79d8b95d09e4678566e8d70105c4e7b251f707a03df32442661b"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "winapi"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@ mod gresource;
 
 use gtk::prelude::*;
 use gtk_extras::{
-    settings::{GeditPreferencesEditor, GnomeDesktopInterface},
-    ImageSelection, ImageSrc, SelectionVariant, ToggleVariant, VariantToggler,
+    settings::{GeditPreferencesEditor, GnomeDesktopInterface, MeldPreferencesEditor},
+    ImageSelection, ImageSrc, SelectionVariant,
 };
 
 use std::cell::Cell;
@@ -14,19 +14,10 @@ use std::rc::Rc;
 use std::ops::Deref;
 
 #[derive(Clone, Copy, Debug)]
-enum ThemeVariant {
-    Dark,
-    Slim,
-}
-
-#[derive(Clone, Copy, Debug)]
 enum ThemeSelection {
     Light,
     Dark,
 }
-
-pub const DARK: u8 = 0b01;
-pub const SLIM: u8 = 0b10;
 
 pub struct PopThemeSwitcher(gtk::Container);
 
@@ -34,8 +25,9 @@ impl PopThemeSwitcher {
     pub fn new() -> Self {
         gresource::init().expect("failed to init pop-theme-switcher gresource");
 
-        let gpe = GeditPreferencesEditor::new_checked();
         let gdi = GnomeDesktopInterface::new();
+        let gpe = GeditPreferencesEditor::new_checked();
+        let mpe = MeldPreferencesEditor::new_checked();
 
         let variants = {
             let current_theme = gdi.gtk_theme();
@@ -84,92 +76,24 @@ impl PopThemeSwitcher {
 
         selection_ready.set(true);
         rx.attach(None, move |event| {
-            let (gtk_theme, gedit_scheme) = match event {
-                ThemeSelection::Light => ("Pop", "pop-light"),
-                ThemeSelection::Dark => ("Pop-dark", "pop-dark"),
+            let (color_scheme, gtk_theme, gedit_scheme) = match event {
+                ThemeSelection::Light => ("prefer-light", "Pop", "pop-light"),
+                ThemeSelection::Dark => ("prefer-dark", "Pop-dark", "pop-dark"),
             };
 
+            gdi.set_color_scheme(color_scheme);
+            gdi.set_gtk_theme(gtk_theme);
             if let Some(gpe) = gpe.as_ref() {
                 gpe.set_scheme(gedit_scheme);
             }
-            gdi.set_gtk_theme(gtk_theme);
+            if let Some(mpe) = mpe.as_ref() {
+                mpe.set_style_scheme(gedit_scheme);
+            }
 
             glib::Continue(true)
         });
 
         Self((*selection).clone().upcast::<gtk::Container>())
-    }
-
-    pub fn dark_and_slim() -> Self {
-        let gpe = GeditPreferencesEditor::new_checked();
-        let gdi = GnomeDesktopInterface::new();
-
-        let mut flags = 0;
-
-        let variants = {
-            let current_theme = gdi.gtk_theme();
-
-            let dark_mode = current_theme.contains("dark");
-            let slim_mode = current_theme.contains("slim");
-
-            if dark_mode {
-                flags |= DARK;
-            }
-
-            if slim_mode {
-                flags |= SLIM;
-            }
-
-            [
-                ToggleVariant {
-                    name:        "Dark Mode",
-                    description: "Changes your applications to a dark theme for easier viewing at \
-                                  night.",
-                    event:       ThemeVariant::Dark,
-                    active:      dark_mode,
-                },
-                ToggleVariant {
-                    name:        "Slim Mode",
-                    description: "Reduces the height of application headers.",
-                    event:       ThemeVariant::Slim,
-                    active:      slim_mode,
-                },
-            ]
-        };
-
-        let (tx, rx) = glib::MainContext::channel(glib::PRIORITY_DEFAULT);
-
-        let theme_switcher = VariantToggler::new(&variants, move |event, active| {
-            let _ = tx.send((event, active));
-        });
-
-        rx.attach(None, move |(event, active)| {
-            match (event, active) {
-                (ThemeVariant::Dark, true) => flags |= DARK,
-                (ThemeVariant::Dark, false) => flags &= 255 ^ DARK,
-                (ThemeVariant::Slim, true) => flags |= SLIM,
-                (ThemeVariant::Slim, false) => flags &= 255 ^ SLIM,
-            }
-
-            let (gtk_theme, gedit_scheme) = if flags & (DARK | SLIM) == DARK | SLIM {
-                ("Pop-slim-dark", "pop-dark")
-            } else if flags & DARK != 0 {
-                ("Pop-dark", "pop-dark")
-            } else if flags & SLIM != 0 {
-                ("Pop-slim", "pop-light")
-            } else {
-                ("Pop", "pop-light")
-            };
-
-            if let Some(gpe) = gpe.as_ref() {
-                gpe.set_scheme(gedit_scheme);
-            }
-            gdi.set_gtk_theme(gtk_theme);
-
-            glib::Continue(true)
-        });
-
-        Self(theme_switcher.into())
     }
 
     pub fn grab_focus(&self) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,12 +26,6 @@ fn main() {
                 PopThemeSwitcher::new();
                 ..set_border_width(12);
             });
-            // ..add(&cascade! {
-            //     gtk::Frame::new(None);
-            //     ..set_halign(gtk::Align::Center);
-            //     ..set_border_width(12);
-            //     ..add(&*PopThemeSwitcher::dark_and_slim());
-            // });
         };
 
         let headerbar = gtk::HeaderBarBuilder::new()


### PR DESCRIPTION
This also required a change in gtk-extras that I just pushed: https://github.com/pop-os/gtk-extras/commit/8dae9fee5f6d79a9e3c225308a9a8c54709dc8c3

This will fix some applications in 22.04 not changing theme:

- evince
- gedit
- meld
- nautilus